### PR TITLE
Bumped version number for Mono.Cecil

### DIFF
--- a/ProjectInfo.cs
+++ b/ProjectInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible (false)]
 #endif
 
-[assembly: AssemblyVersion ("0.9.6.0")]
-[assembly: AssemblyFileVersion ("0.9.6.0")]
+[assembly: AssemblyVersion ("0.9.66.0")]
+[assembly: AssemblyFileVersion ("0.9.66.0")]


### PR DESCRIPTION
Some breaking changes from upstream were added but the version number
was not bumped. This caused issues with some tools (like nunit runner)