### PR TITLE
Do not project for windows runtime during read.

### DIFF
--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -1070,7 +1070,13 @@ namespace Mono.Cecil {
 			if (type != null)
 				return type;
 
-			return ReadTypeDefinition (rid);
+			type = ReadTypeDefinition (rid);
+
+			if (module.IsWindowsMetadata()) {
+				WindowsRuntimeProjections.Project (type);
+			}
+
+			return type;
 		}
 
 		TypeDefinition ReadTypeDefinition (uint rid)

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Author:
 //   Jb Evain (jbevain@gmail.com)
 //
@@ -855,6 +855,12 @@ namespace Mono.Cecil {
 
 				types [i] = ReadType (i + 1);
 			}
+
+			if (module.IsWindowsMetadata()) {
+				for (uint i = 0; i < length; i++) {
+					WindowsRuntimeProjections.Project (types [i]);
+				}
+			}
 		}
 
 		static bool IsNested (TypeAttributes attributes)
@@ -969,9 +975,6 @@ namespace Mono.Cecil {
 
 			if (IsNested (attributes))
 				type.DeclaringType = GetNestedTypeDeclaringType (type);
-
-			if (module.IsWindowsMetadata ())
-				WindowsRuntimeProjections.Project (type);
 
 			return type;
 		}


### PR DESCRIPTION
A type will not be fully initialized during read, so don't attempt to
project for Windows runtime until after all of the metadata reading is
correct.

If a type reading for a module is no completed, a call to
BinaryRangeSearch in MetadataSystem can fail, because some of the
entries in the types array will still be null.