### PR TITLE
Fix reading scopes from MDBs (Unity case 949806).

### DIFF
--- a/Mono.Cecil.Cil/CodeReader.cs
+++ b/Mono.Cecil.Cil/CodeReader.cs
@@ -162,10 +162,12 @@ namespace Mono.Cecil.Cil {
 			var start_instruction = GetInstruction (scope.Start.Offset);
 			scope.Start = new InstructionOffset (start_instruction);
 
-			var end_instruction = GetInstruction (scope.End.Offset);
-			scope.End = end_instruction != null
-				? new InstructionOffset (end_instruction)
-				: new InstructionOffset ();
+			if (!scope.End.IsEndOfMethod) {
+				var end_instruction = GetInstruction (scope.End.Offset);
+				scope.End = end_instruction != null
+					? new InstructionOffset (end_instruction)
+					: new InstructionOffset ();
+			}
 
 			if (!scope.variables.IsNullOrEmpty ()) {
 				for (int i = 0; i < scope.variables.Count; i++) {

--- a/symbols/mdb/Mono.Cecil.Mdb/MdbReader.cs
+++ b/symbols/mdb/Mono.Cecil.Mdb/MdbReader.cs
@@ -144,7 +144,7 @@ namespace Mono.Cecil.Mdb {
 
 			info.scope = scopes [0] = new ScopeDebugInformation {
 				Start = new InstructionOffset (0),
-				End = new InstructionOffset (info.code_size),
+				End = new InstructionOffset(),
 			};
 
 			foreach (var block in blocks) {


### PR DESCRIPTION
At some point, reading MDBs was broken upstream. When we merged upstream in 2017.2, debugging scripts on .NET scripting backend got broken. This fixes it.