### PR TITLE
Fix reading scopes from MDBs (Unity case 949806).

### DIFF
--- a/Mono.Cecil.Cil/CodeReader.cs
+++ b/Mono.Cecil.Cil/CodeReader.cs
@@ -62,6 +62,30 @@ namespace Mono.Cecil.Cil {
 			return this.body;
 		}
 
+		public int ReadCodeSize (MethodDefinition method)
+		{
+			var position = MoveTo (method);
+
+			var code_size = ReadCodeSize ();
+
+			MoveBackTo (position);
+			return code_size;
+		}
+
+		int ReadCodeSize ()
+		{
+			var flags = ReadByte ();
+			switch (flags & 0x3) {
+			case 0x2: // tiny
+				return flags >> 2;
+			case 0x3: // fat
+				Advance (-1 + 2 + 2); // go back, 2 bytes flags, 2 bytes stack size
+				return (int) ReadUInt32 ();
+			default:
+				throw new InvalidOperationException ();
+			}
+		}
+
 		void ReadMethodBody ()
 		{
 			var flags = ReadByte ();
@@ -160,7 +184,8 @@ namespace Mono.Cecil.Cil {
 		void ReadScope (ScopeDebugInformation scope)
 		{
 			var start_instruction = GetInstruction (scope.Start.Offset);
-			scope.Start = new InstructionOffset (start_instruction);
+			if (start_instruction != null)
+				scope.Start = new InstructionOffset (start_instruction);
 
 			var end_instruction = GetInstruction (scope.End.Offset);
 			scope.End = end_instruction != null

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -2121,6 +2121,11 @@ namespace Mono.Cecil {
 			return code.ReadMethodBody (method);
 		}
 
+		public int ReadCodeSize (MethodDefinition method)
+		{
+			return code.ReadCodeSize (method);
+		}
+
 		public CallSite ReadCallSite (MetadataToken token)
 		{
 			if (!MoveTo (Table.StandAloneSig, token.RID))

--- a/symbols/mdb/Mono.Cecil.Mdb/MdbReader.cs
+++ b/symbols/mdb/Mono.Cecil.Mdb/MdbReader.cs
@@ -78,12 +78,18 @@ namespace Mono.Cecil.Mdb {
 				return null;
 
 			var info = new MethodDebugInformation (method);
+			info.code_size = ReadCodeSize (method);
 
 			var scopes = ReadScopes (entry, info);
 			ReadLineNumbers (entry, info);
 			ReadLocalVariables (entry, scopes);
 
 			return info;
+		}
+
+		static int ReadCodeSize (MethodDefinition method)
+		{
+			return method.Module.Read (method, (m, reader) => reader.ReadCodeSize (m));
 		}
 
 		static void ReadLocalVariables (MethodEntry entry, ScopeDebugInformation [] scopes)


### PR DESCRIPTION
At some point, reading MDBs was broken upstream. When we merged upstream in 2017.2, debugging scripts on .NET scripting  backend got broken. This fixes it.