### PR TITLE
Fix reading broken MDBs emitted by mcs

### DIFF
--- a/symbols/mdb/Mono.Cecil.Mdb/MdbReader.cs
+++ b/symbols/mdb/Mono.Cecil.Mdb/MdbReader.cs
@@ -190,7 +190,7 @@ namespace Mono.Cecil.Mdb {
 			var source = symbol_file.GetSourceFile (line.File);
 			return new SequencePoint (line.Offset, GetDocument (source)) {
 				StartLine = line.Row,
-				EndLine = line.EndRow,
+				EndLine = line.EndRow != -1 ? line.EndRow : line.Row,
 				StartColumn = line.Column,
 				EndColumn = line.EndColumn,
 			};


### PR DESCRIPTION
If sequence point ends at row -1, assume that the sequence point is just for a single line. This fixes Unity case 953154.

@jbevain reviewed the change and said it looked reasonable.