### PR TITLE
Improve thread-safety of lazy initializations

### DIFF
--- a/Mono.Cecil.Cil/MethodBody.cs
+++ b/Mono.Cecil.Cil/MethodBody.cs
@@ -56,7 +56,12 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public Collection<Instruction> Instructions {
-			get { return instructions ?? (instructions = new InstructionCollection (method)); }
+			get {
+				if (instructions == null)
+					Interlocked.CompareExchange (ref instructions, new InstructionCollection(method), null);
+
+				return instructions;
+			}
 		}
 
 		public bool HasExceptionHandlers {
@@ -64,7 +69,12 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public Collection<ExceptionHandler> ExceptionHandlers {
-			get { return exceptions ?? (exceptions = new Collection<ExceptionHandler> ()); }
+			get {
+				if (exceptions == null)
+					Interlocked.CompareExchange (ref exceptions, new Collection<ExceptionHandler> (), null);
+
+				return exceptions;
+			}
 		}
 
 		public bool HasVariables {
@@ -72,7 +82,12 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public Collection<VariableDefinition> Variables {
-			get { return variables ?? (variables = new VariableDefinitionCollection ()); }
+			get	{
+				if (variables == null)
+					Interlocked.CompareExchange (ref variables, new VariableDefinitionCollection(), null);
+
+				return variables;
+			}
 		}
 
 		public ScopeDebugInformation Scope {

--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 using SR = System.Reflection;
 
 using Mono.Collections.Generic;
@@ -117,7 +118,12 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public Collection<ScopeDebugInformation> Scopes {
-			get { return scopes ?? (scopes = new Collection<ScopeDebugInformation> ()); }
+			get {
+				if (scopes == null)
+					Interlocked.CompareExchange (ref scopes, new Collection<ScopeDebugInformation> (), null);
+
+				return scopes;
+			}
 		}
 
 		public bool HasVariables {
@@ -125,7 +131,12 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public Collection<VariableDebugInformation> Variables {
-			get { return variables ?? (variables = new Collection<VariableDebugInformation> ()); }
+			get {
+				if (variables == null)
+					Interlocked.CompareExchange (ref variables, new Collection<VariableDebugInformation> (), null);
+
+				return variables;
+			}
 		}
 
 		public bool HasConstants {
@@ -133,7 +144,12 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public Collection<ConstantDebugInformation> Constants {
-			get { return constants ?? (constants = new Collection<ConstantDebugInformation> ()); }
+			get {
+				if (constants == null)
+					Interlocked.CompareExchange (ref constants, new Collection<ConstantDebugInformation> (), null);
+
+				return constants;
+			}
 		}
 
 		internal ScopeDebugInformation ()
@@ -258,7 +274,12 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public Collection<CustomDebugInformation> CustomDebugInformations {
-			get { return custom_infos ?? (custom_infos = new Collection<CustomDebugInformation> ()); }
+			get {
+				if (custom_infos == null)
+					Interlocked.CompareExchange (ref custom_infos, new Collection<CustomDebugInformation> (), null);
+
+				return custom_infos;
+			}
 		}
 
 		internal DebugInformation ()
@@ -408,7 +429,13 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public Collection<ImportTarget> Targets {
-			get { return targets ?? (targets = new Collection<ImportTarget> ()); }
+			get
+			{
+				if (targets == null)
+					Interlocked.CompareExchange (ref targets, new Collection<ImportTarget> (), null);
+
+				return targets;
+			}
 		}
 
 		public ImportDebugInformation Parent {
@@ -487,11 +514,21 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public Collection<InstructionOffset> Yields {
-			get { return yields ?? (yields = new Collection<InstructionOffset> ()); }
+			get {
+				if (yields == null)
+					Interlocked.CompareExchange (ref yields, new Collection<InstructionOffset> (), null);
+
+				return yields;
+			}
 		}
 
 		public Collection<InstructionOffset> Resumes {
-			get { return resumes ?? (resumes = new Collection<InstructionOffset> ()); }
+			get {
+				if (resumes == null)
+					Interlocked.CompareExchange (ref resumes, new Collection<InstructionOffset> (), null);
+
+				return resumes;
+			}
 		}
 
 		public MethodDefinition MoveNextMethod {
@@ -629,7 +666,12 @@ namespace Mono.Cecil.Cil {
 		}
 
 		public Collection<SequencePoint> SequencePoints {
-			get { return sequence_points ?? (sequence_points = new Collection<SequencePoint> ()); }
+			get {
+				if (sequence_points == null)
+					Interlocked.CompareExchange (ref sequence_points, new Collection<SequencePoint> (), null);
+
+				return sequence_points;
+			}
 		}
 
 		public ScopeDebugInformation Scope {

--- a/Mono.Cecil/ArrayType.cs
+++ b/Mono.Cecil/ArrayType.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Text;
+using System.Threading;
 using Mono.Collections.Generic;
 using MD = Mono.Cecil.Metadata;
 
@@ -57,8 +58,11 @@ namespace Mono.Cecil {
 				if (dimensions != null)
 					return dimensions;
 
-				dimensions = new Collection<ArrayDimension> ();
-				dimensions.Add (new ArrayDimension ());
+				var empty_dimensions = new Collection<ArrayDimension> ();
+				empty_dimensions.Add (new ArrayDimension ());
+
+				Interlocked.CompareExchange (ref dimensions, empty_dimensions, null);
+
 				return dimensions;
 			}
 		}

--- a/Mono.Cecil/AssemblyDefinition.cs
+++ b/Mono.Cecil/AssemblyDefinition.cs
@@ -10,7 +10,7 @@
 
 using System;
 using System.IO;
-
+using System.Threading;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -46,7 +46,8 @@ namespace Mono.Cecil {
 				if (main_module.HasImage)
 					return main_module.Read (ref modules, this, (_, reader) => reader.ReadModules ());
 
-				return modules = new Collection<ModuleDefinition> (1) { main_module };
+				Interlocked.CompareExchange (ref modules, new Collection<ModuleDefinition> (1) { main_module }, null);
+				return modules;
 			}
 		}
 

--- a/Mono.Cecil/AssemblyNameReference.cs
+++ b/Mono.Cecil/AssemblyNameReference.cs
@@ -85,14 +85,14 @@ namespace Mono.Cecil {
 			set {
 				public_key = value;
 				HasPublicKey = !public_key.IsNullOrEmpty ();
-				public_key_token = Empty<byte>.Array;
+				public_key_token = null;
 				full_name = null;
 			}
 		}
 
 		public byte [] PublicKeyToken {
 			get {
-				if (public_key_token.IsNullOrEmpty () && !public_key.IsNullOrEmpty ()) {
+				if (public_key_token == null && !public_key.IsNullOrEmpty ()) {
 					var hash = HashPublicKey ();
 					// we need the last 8 bytes in reverse order
 					var local_public_key_token = new byte [8];

--- a/Mono.Cecil/AssemblyNameReference.cs
+++ b/Mono.Cecil/AssemblyNameReference.cs
@@ -12,6 +12,7 @@ using System;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 
 namespace Mono.Cecil {
 
@@ -97,7 +98,7 @@ namespace Mono.Cecil {
 					var local_public_key_token = new byte [8];
 					Array.Copy (hash, (hash.Length - 8), local_public_key_token, 0, 8);
 					Array.Reverse (local_public_key_token, 0, 8);
-					public_key_token = local_public_key_token; // publish only once finished (required for thread-safety)
+					Interlocked.CompareExchange (ref public_key_token, local_public_key_token, null); // publish only once finished (required for thread-safety)
 				}
 				return public_key_token ?? Empty<byte>.Array;
 			}
@@ -160,7 +161,9 @@ namespace Mono.Cecil {
 					builder.Append ("Retargetable=Yes");
 				}
 
-				return full_name = builder.ToString ();
+				Interlocked.CompareExchange (ref full_name, builder.ToString (), null);
+
+				return full_name;
 			}
 		}
 

--- a/Mono.Cecil/CustomAttribute.cs
+++ b/Mono.Cecil/CustomAttribute.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -103,7 +104,10 @@ namespace Mono.Cecil {
 			get {
 				Resolve ();
 
-				return arguments ?? (arguments = new Collection<CustomAttributeArgument> ());
+				if (arguments == null)
+					Interlocked.CompareExchange (ref arguments, new Collection<CustomAttributeArgument> (), null);
+
+				return arguments;
 			}
 		}
 
@@ -119,7 +123,10 @@ namespace Mono.Cecil {
 			get {
 				Resolve ();
 
-				return fields ?? (fields = new Collection<CustomAttributeNamedArgument> ());
+				if (fields == null)
+					Interlocked.CompareExchange (ref fields, new Collection<CustomAttributeNamedArgument> (), null);
+
+				return fields;
 			}
 		}
 
@@ -135,7 +142,10 @@ namespace Mono.Cecil {
 			get {
 				Resolve ();
 
-				return properties ?? (properties = new Collection<CustomAttributeNamedArgument> ());
+				if (properties == null)
+					Interlocked.CompareExchange (ref properties, new Collection<CustomAttributeNamedArgument> (), null);
+
+				return properties;
 			}
 		}
 
@@ -183,22 +193,27 @@ namespace Mono.Cecil {
 			if (resolved || !HasImage)
 				return;
 
-			Module.Read (this, (attribute, reader) => {
-				try {
-					reader.ReadCustomAttributeSignature (attribute);
-					resolved = true;
-				} catch (ResolutionException) {
-					if (arguments != null)
-						arguments.Clear ();
-					if (fields != null)
-						fields.Clear ();
-					if (properties != null)
-						properties.Clear ();
+			lock (Module.SyncRoot) {
+				if (resolved)
+					return;
 
-					resolved = false;
-				}
-				return this;
-			});
+				Module.Read (this, (attribute, reader) => {
+					try {
+						reader.ReadCustomAttributeSignature (attribute);
+						resolved = true;
+					} catch (ResolutionException) {
+						if (arguments != null)
+							arguments.Clear ();
+						if (fields != null)
+							fields.Clear ();
+						if (properties != null)
+							properties.Clear ();
+
+						resolved = false;
+					}
+					return this;
+				});
+			}
 		}
 	}
 }

--- a/Mono.Cecil/EventDefinition.cs
+++ b/Mono.Cecil/EventDefinition.cs
@@ -8,6 +8,7 @@
 // Licensed under the MIT/X11 license.
 //
 
+using System.Threading;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -78,10 +79,10 @@ namespace Mono.Cecil {
 
 				InitializeMethods ();
 
-				if (other_methods != null)
-					return other_methods;
+				if (other_methods == null)
+					Interlocked.CompareExchange (ref other_methods, new Collection<MethodDefinition> (), null);
 
-				return other_methods = new Collection<MethodDefinition> ();
+				return other_methods;
 			}
 		}
 

--- a/Mono.Cecil/FieldDefinition.cs
+++ b/Mono.Cecil/FieldDefinition.cs
@@ -9,6 +9,7 @@
 //
 
 using System;
+using System.Threading;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -37,7 +38,11 @@ namespace Mono.Cecil {
 				return;
 			}
 
-			offset = Module.Read (this, (field, reader) => reader.ReadFieldLayout (field));
+			lock (Module.SyncRoot) {
+				if (offset != Mixin.NotResolvedMarker)
+					return;
+				offset = Module.Read (this, (field, reader) => reader.ReadFieldLayout (field));
+			}
 		}
 
 		public bool HasLayoutInfo {
@@ -76,7 +81,11 @@ namespace Mono.Cecil {
 			if (!HasImage)
 				return;
 
-			rva = Module.Read (this, (field, reader) => reader.ReadFieldRVA (field));
+			lock (Module.SyncRoot) {
+				if (rva != Mixin.NotResolvedMarker)
+					return;
+				rva = Module.Read (this, (field, reader) => reader.ReadFieldRVA (field));
+			}
 		}
 
 		public int RVA {

--- a/Mono.Cecil/GenericInstanceMethod.cs
+++ b/Mono.Cecil/GenericInstanceMethod.cs
@@ -10,7 +10,7 @@
 
 using System;
 using System.Text;
-
+using System.Threading;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -24,7 +24,12 @@ namespace Mono.Cecil {
 		}
 
 		public Collection<TypeReference> GenericArguments {
-			get { return arguments ?? (arguments = new Collection<TypeReference> ()); }
+			get {
+				if (arguments == null)
+					Interlocked.CompareExchange (ref arguments, new Collection<TypeReference> (), null);
+
+				return arguments;
+			}
 		}
 
 		public override bool IsGenericInstance {

--- a/Mono.Cecil/GenericInstanceType.cs
+++ b/Mono.Cecil/GenericInstanceType.cs
@@ -10,7 +10,7 @@
 
 using System;
 using System.Text;
-
+using System.Threading;
 using Mono.Collections.Generic;
 
 using MD = Mono.Cecil.Metadata;
@@ -26,7 +26,12 @@ namespace Mono.Cecil {
 		}
 
 		public Collection<TypeReference> GenericArguments {
-			get { return arguments ?? (arguments = new Collection<TypeReference> ()); }
+			get {
+				if (arguments == null)
+					Interlocked.CompareExchange (ref arguments, new Collection<TypeReference> (), null);
+
+				return arguments;
+			}
 		}
 
 		public override TypeReference DeclaringType {

--- a/Mono.Cecil/ICustomAttributeProvider.cs
+++ b/Mono.Cecil/ICustomAttributeProvider.cs
@@ -9,6 +9,7 @@
 //
 
 using System;
+using System.Threading;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -34,9 +35,11 @@ namespace Mono.Cecil {
 			ref Collection<CustomAttribute> variable,
 			ModuleDefinition module)
 		{
-			return module.HasImage ()
-				? module.Read (ref variable, self, (provider, reader) => reader.ReadCustomAttributes (provider))
-				: variable = new Collection<CustomAttribute>();
+			if (module.HasImage ())
+				return module.Read (ref variable, self, (provider, reader) => reader.ReadCustomAttributes (provider));
+
+			Interlocked.CompareExchange (ref variable, new Collection<CustomAttribute> (), null);
+			return variable;
 		}
 	}
 }

--- a/Mono.Cecil/IGenericParameterProvider.cs
+++ b/Mono.Cecil/IGenericParameterProvider.cs
@@ -8,7 +8,7 @@
 // Licensed under the MIT/X11 license.
 //
 
-
+using System.Threading;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -48,9 +48,11 @@ namespace Mono.Cecil {
 			ref Collection<GenericParameter> collection,
 			ModuleDefinition module)
 		{
-			return module.HasImage ()
-				? module.Read (ref collection, self, (provider, reader) => reader.ReadGenericParameters (provider))
-				: collection = new GenericParameterCollection (self);
+			if (module.HasImage ())
+				return module.Read (ref collection, self, (provider, reader) => reader.ReadGenericParameters (provider));
+
+			Interlocked.CompareExchange (ref collection, new GenericParameterCollection (self), null);
+			return collection;
 		}
 	}
 }

--- a/Mono.Cecil/MetadataSystem.cs
+++ b/Mono.Cecil/MetadataSystem.cs
@@ -10,7 +10,8 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Metadata;
 using Mono.Collections.Generic;
@@ -68,7 +69,7 @@ namespace Mono.Cecil {
 
 		static void InitializePrimitives ()
 		{
-			primitive_value_types = new Dictionary<string, Row<ElementType, bool>> (18, StringComparer.Ordinal) {
+			var types = new Dictionary<string, Row<ElementType, bool>> (18, StringComparer.Ordinal) {
 				{ "Void", new Row<ElementType, bool> (ElementType.Void, false) },
 				{ "Boolean", new Row<ElementType, bool> (ElementType.Boolean, true) },
 				{ "Char", new Row<ElementType, bool> (ElementType.Char, true) },
@@ -88,6 +89,8 @@ namespace Mono.Cecil {
 				{ "UIntPtr", new Row<ElementType, bool> (ElementType.U, true) },
 				{ "Object", new Row<ElementType, bool> (ElementType.Object, false) },
 			};
+
+			Interlocked.CompareExchange (ref primitive_value_types, types, null);
 		}
 
 		public static void TryProcessPrimitiveTypeReference (TypeReference type)

--- a/Mono.Cecil/MethodDefinition.cs
+++ b/Mono.Cecil/MethodDefinition.cs
@@ -9,6 +9,7 @@
 //
 
 using System;
+using System.Threading;
 using Mono.Cecil.Cil;
 using Mono.Collections.Generic;
 
@@ -97,7 +98,12 @@ namespace Mono.Cecil {
 			if (!module.HasImage)
 				return;
 
-			module.Read (this, (method, reader) => reader.ReadAllSemantics (method));
+			lock (module.SyncRoot) {
+				if (sem_attrs_ready)
+					return;
+
+				module.Read (this, (method, reader) => reader.ReadAllSemantics (method));
+			}
 		}
 
 		public bool HasSecurityDeclarations {
@@ -153,7 +159,9 @@ namespace Mono.Cecil {
 				if (HasImage && rva != 0)
 					return Module.Read (ref body, this, (method, reader) => reader.ReadMethodBody (method));
 
-				return body = new MethodBody (this);
+				Interlocked.CompareExchange (ref body, new MethodBody (this) , null);
+
+				return body;
 			}
 			set {
 				var module = this.Module;
@@ -173,10 +181,11 @@ namespace Mono.Cecil {
 			get {
 				Mixin.Read (Body);
 
-				if (debug_info != null)
-					return debug_info;
+				if (debug_info == null) {
+					Interlocked.CompareExchange (ref debug_info, new MethodDebugInformation (this), null);
+				}
 
-				return debug_info ?? (debug_info = new MethodDebugInformation (this));
+				return debug_info;
 			}
 		}
 
@@ -222,7 +231,9 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Module.Read (ref overrides, this, (method, reader) => reader.ReadOverrides (method));
 
-				return overrides = new Collection<MethodReference> ();
+				Interlocked.CompareExchange (ref overrides, new Collection<MethodReference> (), null);
+
+				return overrides;
 			}
 		}
 
@@ -251,7 +262,10 @@ namespace Mono.Cecil {
 			get {
 				Mixin.Read (Body);
 
-				return custom_infos ?? (custom_infos = new Collection<CustomDebugInformation> ());
+				if (custom_infos == null)
+					Interlocked.CompareExchange (ref custom_infos, new Collection<CustomDebugInformation> (), null);
+
+				return custom_infos;
 			}
 		}
 

--- a/Mono.Cecil/MethodReference.cs
+++ b/Mono.Cecil/MethodReference.cs
@@ -10,7 +10,7 @@
 
 using System;
 using System.Text;
-
+using System.Threading;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -47,7 +47,7 @@ namespace Mono.Cecil {
 		public virtual Collection<ParameterDefinition> Parameters {
 			get {
 				if (parameters == null)
-					parameters = new ParameterDefinitionCollection (this);
+					Interlocked.CompareExchange (ref parameters, new ParameterDefinitionCollection (this), null);
 
 				return parameters;
 			}
@@ -78,10 +78,10 @@ namespace Mono.Cecil {
 
 		public virtual Collection<GenericParameter> GenericParameters {
 			get {
-				if (generic_parameters != null)
-					return generic_parameters;
+				if (generic_parameters == null)
+					Interlocked.CompareExchange (ref generic_parameters, new GenericParameterCollection (this), null);
 
-				return generic_parameters = new GenericParameterCollection (this);
+				return generic_parameters;
 			}
 		}
 

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -442,7 +442,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Read (ref references, this, (_, reader) => reader.ReadAssemblyReferences ());
 
-				return references = new Collection<AssemblyNameReference> ();
+				Interlocked.CompareExchange (ref references, new Collection<AssemblyNameReference> (), null);
+				return references;
 			}
 		}
 
@@ -463,7 +464,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Read (ref modules, this, (_, reader) => reader.ReadModuleReferences ());
 
-				return modules = new Collection<ModuleReference> ();
+				Interlocked.CompareExchange (ref modules, new Collection<ModuleReference> (), null);
+				return modules;
 			}
 		}
 
@@ -487,7 +489,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Read (ref resources, this, (_, reader) => reader.ReadResources ());
 
-				return resources = new Collection<Resource> ();
+				Interlocked.CompareExchange (ref resources, new Collection<Resource> (), null);
+				return resources;
 			}
 		}
 
@@ -521,7 +524,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Read (ref types, this, (_, reader) => reader.ReadTypes ());
 
-				return types = new TypeDefinitionCollection (this);
+				Interlocked.CompareExchange (ref types, new TypeDefinitionCollection (this), null);
+				return types;
 			}
 		}
 
@@ -542,7 +546,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Read (ref exported_types, this, (_, reader) => reader.ReadExportedTypes ());
 
-				return exported_types = new Collection<ExportedType> ();
+				Interlocked.CompareExchange (ref exported_types, new Collection<ExportedType> (), null);
+				return exported_types;
 			}
 		}
 
@@ -567,7 +572,10 @@ namespace Mono.Cecil {
 
 		public Collection<CustomDebugInformation> CustomDebugInformations {
 			get {
-				return custom_infos ?? (custom_infos = new Collection<CustomDebugInformation> ());
+				if (custom_infos == null)
+					Interlocked.CompareExchange (ref custom_infos, new Collection<CustomDebugInformation> (), null);
+
+				return custom_infos;
 			}
 		}
 

--- a/Mono.Cecil/PropertyDefinition.cs
+++ b/Mono.Cecil/PropertyDefinition.cs
@@ -9,7 +9,7 @@
 //
 
 using System.Text;
-
+using System.Threading;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -103,7 +103,8 @@ namespace Mono.Cecil {
 				if (other_methods != null)
 					return other_methods;
 
-				return other_methods = new Collection<MethodDefinition> ();
+				Interlocked.CompareExchange (ref other_methods, new Collection<MethodDefinition> (), null);
+				return other_methods;
 			}
 		}
 

--- a/Mono.Cecil/SecurityDeclaration.cs
+++ b/Mono.Cecil/SecurityDeclaration.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 using Mono.Collections.Generic;
 
 namespace Mono.Cecil {
@@ -56,15 +57,25 @@ namespace Mono.Cecil {
 		}
 
 		public Collection<CustomAttributeNamedArgument> Fields {
-			get { return fields ?? (fields = new Collection<CustomAttributeNamedArgument> ()); }
+			get {
+				if (fields == null)
+					Interlocked.CompareExchange (ref fields, new Collection<CustomAttributeNamedArgument> (), null);
+
+				return fields;
+			}
 		}
 
 		public bool HasProperties {
 			get { return !properties.IsNullOrEmpty (); }
 		}
+		
+		public Collection<CustomAttributeNamedArgument> Properties { 
+			get {
+				if (properties == null)
+					Interlocked.CompareExchange (ref properties, new Collection<CustomAttributeNamedArgument> (), null);
 
-		public Collection<CustomAttributeNamedArgument> Properties {
-			get { return properties ?? (properties = new Collection<CustomAttributeNamedArgument> ()); }
+				return properties;
+			}
 		}
 
 		public SecurityAttribute (TypeReference attributeType)
@@ -100,7 +111,10 @@ namespace Mono.Cecil {
 			get {
 				Resolve ();
 
-				return security_attributes ?? (security_attributes = new Collection<SecurityAttribute> ());
+				if (security_attributes == null) 
+					Interlocked.CompareExchange (ref security_attributes, new Collection<SecurityAttribute> (), null);
+
+				return security_attributes;
 			}
 		}
 
@@ -136,7 +150,7 @@ namespace Mono.Cecil {
 			if (!HasImage || signature == 0)
 				throw new NotSupportedException ();
 
-			return blob = module.Read (this, (declaration, reader) => reader.ReadSecurityDeclarationBlob (declaration.signature));
+			return module.Read (ref blob, this, (declaration, reader) => reader.ReadSecurityDeclarationBlob (declaration.signature));
 		}
 
 		void Resolve ()
@@ -144,12 +158,18 @@ namespace Mono.Cecil {
 			if (resolved || !HasImage)
 				return;
 
-			module.Read (this, (declaration, reader) => {
-				reader.ReadSecurityDeclarationSignature (declaration);
-				return this;
-			});
+			lock (module.SyncRoot) {
 
-			resolved = true;
+				if (resolved)
+					return;
+
+				module.Read (this, (declaration, reader) => {
+					reader.ReadSecurityDeclarationSignature (declaration);
+					return this;
+				});
+
+				resolved = true;
+			}
 		}
 	}
 
@@ -167,9 +187,11 @@ namespace Mono.Cecil {
 			ref Collection<SecurityDeclaration> variable,
 			ModuleDefinition module)
 		{
-			return module.HasImage ()
-				? module.Read (ref variable, self, (provider, reader) => reader.ReadSecurityDeclarations (provider))
-				: variable = new Collection<SecurityDeclaration>();
+			if (module.HasImage)
+				return module.Read (ref variable, self, (provider, reader) => reader.ReadSecurityDeclarations (provider));
+
+			Interlocked.CompareExchange (ref variable, new Collection<SecurityDeclaration> (), null);
+			return variable;
 		}
 	}
 }

--- a/Mono.Cecil/TypeDefinition.cs
+++ b/Mono.Cecil/TypeDefinition.cs
@@ -9,7 +9,7 @@
 //
 
 using System;
-
+using System.Threading;
 using Mono.Cecil.Metadata;
 using Mono.Collections.Generic;
 
@@ -61,19 +61,21 @@ namespace Mono.Cecil {
 
 		void ResolveLayout ()
 		{
-			if (packing_size != Mixin.NotResolvedMarker || class_size != Mixin.NotResolvedMarker)
-				return;
-
 			if (!HasImage) {
 				packing_size = Mixin.NoDataMarker;
 				class_size = Mixin.NoDataMarker;
 				return;
 			}
 
-			var row = Module.Read (this, (type, reader) => reader.ReadTypeLayout (type));
+			lock (Module.SyncRoot) {
+				if (packing_size != Mixin.NotResolvedMarker || class_size != Mixin.NotResolvedMarker)
+					return;
 
-			packing_size = row.Col1;
-			class_size = row.Col2;
+				var row = Module.Read (this, (type, reader) => reader.ReadTypeLayout (type));
+
+				packing_size = row.Col1;
+				class_size = row.Col2;
+			}
 		}
 
 		public bool HasLayoutInfo {
@@ -128,7 +130,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Module.Read (ref interfaces, this, (type, reader) => reader.ReadInterfaces (type));
 
-				return interfaces = new InterfaceImplementationCollection (this);
+				Interlocked.CompareExchange (ref interfaces, new InterfaceImplementationCollection (this), null);
+				return interfaces;
 			}
 		}
 
@@ -149,7 +152,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Module.Read (ref nested_types, this, (type, reader) => reader.ReadNestedTypes (type));
 
-				return nested_types = new MemberDefinitionCollection<TypeDefinition> (this);
+				Interlocked.CompareExchange (ref nested_types, new MemberDefinitionCollection<TypeDefinition> (this), null);
+				return nested_types;
 			}
 		}
 
@@ -170,7 +174,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Module.Read (ref methods, this, (type, reader) => reader.ReadMethods (type));
 
-				return methods = new MemberDefinitionCollection<MethodDefinition> (this);
+				Interlocked.CompareExchange (ref methods, new MemberDefinitionCollection<MethodDefinition> (this) , null);
+				return methods;
 			}
 		}
 
@@ -191,7 +196,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Module.Read (ref fields, this, (type, reader) => reader.ReadFields (type));
 
-				return fields = new MemberDefinitionCollection<FieldDefinition> (this);
+				Interlocked.CompareExchange (ref fields, new MemberDefinitionCollection<FieldDefinition> (this), null);
+				return fields;
 			}
 		}
 
@@ -212,7 +218,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Module.Read (ref events, this, (type, reader) => reader.ReadEvents (type));
 
-				return events = new MemberDefinitionCollection<EventDefinition> (this);
+				Interlocked.CompareExchange (ref events, new MemberDefinitionCollection<EventDefinition> (this), null);
+				return events;
 			}
 		}
 
@@ -233,7 +240,8 @@ namespace Mono.Cecil {
 				if (HasImage)
 					return Module.Read (ref properties, this, (type, reader) => reader.ReadProperties (type));
 
-				return properties = new MemberDefinitionCollection<PropertyDefinition> (this);
+				Interlocked.CompareExchange (ref properties, new MemberDefinitionCollection<PropertyDefinition> (this), null);
+				return properties;
 			}
 		}
 
@@ -508,8 +516,11 @@ namespace Mono.Cecil {
 
 		public Collection<CustomAttribute> CustomAttributes {
 			get {
-				if (type == null)
-					return custom_attributes = new Collection<CustomAttribute> ();
+				if (type == null) {
+					if (custom_attributes == null)
+						Interlocked.CompareExchange (ref custom_attributes, new Collection<CustomAttribute> (), null);
+					return custom_attributes;
+				}
 
 				return custom_attributes ?? (this.GetCustomAttributes (ref custom_attributes, type.Module));
 			}

--- a/Mono.Cecil/TypeReference.cs
+++ b/Mono.Cecil/TypeReference.cs
@@ -9,7 +9,7 @@
 //
 
 using System;
-
+using System.Threading;
 using Mono.Cecil.Metadata;
 using Mono.Collections.Generic;
 
@@ -123,10 +123,10 @@ namespace Mono.Cecil {
 
 		public virtual Collection<GenericParameter> GenericParameters {
 			get {
-				if (generic_parameters != null)
-					return generic_parameters;
-
-				return generic_parameters = new GenericParameterCollection (this);
+				if (generic_parameters == null)
+					Interlocked.CompareExchange (ref generic_parameters, new GenericParameterCollection (this), null);
+					
+				return generic_parameters;
 			}
 		}
 
@@ -172,11 +172,11 @@ namespace Mono.Cecil {
 				if (fullname != null)
 					return fullname;
 
-				fullname = this.TypeFullName ();
+				var new_fullname = this.TypeFullName ();
 
 				if (IsNested)
-					fullname = DeclaringType.FullName + "/" + fullname;
-
+					new_fullname = DeclaringType.FullName + "/" + new_fullname;
+				Interlocked.CompareExchange (ref fullname, new_fullname, null);
 				return fullname;
 			}
 		}

--- a/Mono.Cecil/WindowsRuntimeProjections.cs
+++ b/Mono.Cecil/WindowsRuntimeProjections.cs
@@ -135,7 +135,8 @@ namespace Mono.Cecil {
 				if (projections != null)
 					return projections;
 
-				return projections = new Dictionary<string, ProjectionInfo> {
+
+				var new_projections = new Dictionary<string, ProjectionInfo> {
 					{ "AttributeTargets", new ProjectionInfo ("Windows.Foundation.Metadata", "System", "AttributeTargets", "System.Runtime") },
 					{ "AttributeUsageAttribute", new ProjectionInfo ("Windows.Foundation.Metadata", "System", "AttributeUsageAttribute", "System.Runtime", attribute: true) },
 					{ "Color", new ProjectionInfo ("Windows.UI", "Windows.UI", "Color", "System.Runtime.WindowsRuntime") },
@@ -187,6 +188,9 @@ namespace Mono.Cecil {
 					{ "Vector3", new ProjectionInfo ("Windows.Foundation.Numerics", "System.Numerics", "Vector3", "System.Numerics.Vectors") },
 					{ "Vector4", new ProjectionInfo ("Windows.Foundation.Numerics", "System.Numerics", "Vector4", "System.Numerics.Vectors") },
 				};
+
+				Interlocked.CompareExchange (ref projections, new_projections, null);
+				return projections;
 			}
 		}
 

--- a/Mono.Collections.Generic/ReadOnlyCollection.cs
+++ b/Mono.Collections.Generic/ReadOnlyCollection.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Mono.Collections.Generic {
 
@@ -19,7 +20,14 @@ namespace Mono.Collections.Generic {
 		static ReadOnlyCollection<T> empty;
 
 		public static ReadOnlyCollection<T> Empty {
-			get { return empty ?? (empty = new ReadOnlyCollection<T> ()); }
+			get
+			{
+				if (empty != null)
+					return empty;
+
+				Interlocked.CompareExchange (ref empty, new ReadOnlyCollection<T> (), null);
+				return empty;
+			}
 		}
 
 		bool ICollection<T>.IsReadOnly {


### PR DESCRIPTION
Fixes issues with thread safety on the lazy initializations in Mono.Cecil.

The `Interlocked.Exchange` calls will ensure that the same object is returned from each call even under a race (although we my create more than once, but they are just empty collections).  It should also make sure that no write re-ordering issues occur on platforms that allow that.

The locks on `Module.SyncRoot` are a pattern I copied from elsewhere in the code base.  They are always around a call to `Module.Read` which always takes that same lock itself, so no new locking is really being introduced.