### PR TITLE
Allow duplicate sequence point offset values

### DIFF
--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -714,7 +714,7 @@ namespace Mono.Cecil.Cil {
 			var offset_mapping = new Dictionary<int, SequencePoint> (sequence_points.Count);
 
 			for (int i = 0; i < sequence_points.Count; i++)
-				offset_mapping.Add (sequence_points [i].Offset, sequence_points [i]);
+				offset_mapping[sequence_points [i].Offset] = sequence_points [i];
 
 			var instructions = method.Body.Instructions;
 


### PR DESCRIPTION
In some FSharp PDB files, we have seen duplicate sequence point entries.
These entries have exactly the same information, so nothing is lost by
updating an existing entry with the same information.

This avoids an exception that occurs for duplicate entries with these
FSharp PDB files.